### PR TITLE
Fix: Improved finding team members

### DIFF
--- a/tag-team/library/scripts/assist/assistControllerScript.hx
+++ b/tag-team/library/scripts/assist/assistControllerScript.hx
@@ -30,15 +30,10 @@ function initialize() {
 
 function createTeamMembers() {
     for (c in match.getPlayers()) {
-        Engine.log(c);
-        if (player.getUid() == c.getUid()) {
-            Engine.log('This me');
+        if (player == c) {
             team.push(player);
-        } else {
-            if (c.getTeam() == player.getTeam()) {
-                Engine.log('Teammate found');
-                team.push(c);
-            }
+        } else if (c.getTeam() == player.getTeam()) {
+            team.push(c);
         }
     }
 }


### PR DESCRIPTION
## Summary
The old check for determining who the player was by using the Uid was flawed as if a character was picked with the same Uid on the other team, they would still get added to the team which is incorrect behavior. Checking if c == player works better.

## Changes
- Changed the createTeamMembers function to use player == c instead of checking by uuid.

## Testing
- Pick two characters on opposite teams with the same uuid.